### PR TITLE
593 remove auto focus

### DIFF
--- a/editor/js/editable-js.js
+++ b/editor/js/editable-js.js
@@ -33,7 +33,6 @@
         var editorContainer = document.getElementById('editor');
         // eslint-disable-next-line new-cap
         codeMirror = CodeMirror(editorContainer, {
-            autofocus: true,
             inputStyle: 'contenteditable',
             lineNumbers: true,
             mode: 'javascript',

--- a/editor/js/editor-libs/events.js
+++ b/editor/js/editor-libs/events.js
@@ -1,7 +1,6 @@
 var clippy = require('./clippy');
 var cssEditorUtils = require('./css-editor-utils');
 var mceAnalytics = require('./analytics');
-var mceUtils = require('./mce-utils');
 
 /**
  * Adds listeners for events from the CSS live examples
@@ -22,25 +21,9 @@ function addCSSEditorEventListeners(exampleChoiceList) {
         );
     });
 
-    exampleChoiceList.addEventListener('click', function(event) {
-        var target = event.target;
-
-        // if the original target is not an `example-choice` element
-        if (!target.classList.contains('example-choice')) {
-            // find this element's `example-choice` parent
-            target = mceUtils.findParentChoiceElem(target);
-        }
-
-        if (target.classList.contains('copy')) {
-            mceAnalytics.trackEvent({
-                category: 'Interactive Example - CSS',
-                action: 'Copy to clipboard clicked',
-                label: 'Interaction Events'
-            });
-        }
-
-        // and pass it on to `onChoose`
-        module.exports.onChoose(target);
+    var exampleChoices = exampleChoiceList.querySelectorAll('.example-choice');
+    Array.from(exampleChoices).forEach((choice) => {
+        choice.addEventListener('click', handleChoiceEvent);
     });
 }
 
@@ -150,6 +133,18 @@ function handlePasteEvents(event) {
     parentCodeElem.innerText = startValue + '\n' + clipboardText;
 
     Prism.highlightElement(parentCodeElem);
+}
+
+function handleChoiceEvent() {
+    if (this.classList.contains('copy')) {
+        mceAnalytics.trackEvent({
+            category: 'Interactive Example - CSS',
+            action: 'Copy to clipboard clicked',
+            label: 'Interaction Events',
+        });
+    }
+
+    module.exports.onChoose(this);
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     },
     "dependencies": {
         "browserify": "17.0.0",
-        "clean-css": "5.1.4",
+        "clean-css": "5.1.5",
         "codemirror": "5.62.2",
         "cosmiconfig": "7.0.0",
         "fs-extra": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     ],
     "devDependencies": {
         "bundlesize": "0.18.1",
-        "http-server": "0.12.3",
+        "http-server": "13.0.0",
         "jest": "27.0.6",
         "jest-puppeteer": "5.0.4",
         "npm-run-all": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "dependencies": {
         "browserify": "17.0.0",
         "clean-css": "5.1.3",
-        "codemirror": "5.62.0",
+        "codemirror": "5.62.1",
         "cosmiconfig": "7.0.0",
         "fs-extra": "10.0.0",
         "glob": "7.1.7",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "dependencies": {
         "browserify": "17.0.0",
         "clean-css": "5.1.3",
-        "codemirror": "5.62.1",
+        "codemirror": "5.62.2",
         "cosmiconfig": "7.0.0",
         "fs-extra": "10.0.0",
         "glob": "7.1.7",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
         "jest": "27.0.6",
         "jest-puppeteer": "5.0.4",
         "npm-run-all": "4.1.5",
-        "prettier-eslint": "12.0.0",
+        "prettier-eslint": "13.0.0",
         "puppeteer": "9.1.1"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     },
     "dependencies": {
         "browserify": "17.0.0",
-        "clean-css": "5.1.3",
+        "clean-css": "5.1.4",
         "codemirror": "5.62.2",
         "cosmiconfig": "7.0.0",
         "fs-extra": "10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1657,10 +1657,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codemirror@5.62.0:
-  version "5.62.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.62.0.tgz#e9ecd012e6f9eaf2e05ff4a449ff750f51619e22"
-  integrity sha512-Xnl3304iCc8nyVZuRkzDVVwc794uc9QNX0UcPGeNic1fbzkSrO4l4GVXho9tRNKBgPYZXgocUqXyfIv3BILhCQ==
+codemirror@5.62.1:
+  version "5.62.1"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.62.1.tgz#917c7406c7b7f05b974c7fe4c4f2088ae64cc874"
+  integrity sha512-39ce8tHh/M9J+Epa90R5zMGg06pxVXc1+Y0SRR6eKaUjjzuj5iYkk7rHc2uU+FzvfsWYGEYKPFf0pBVBLmYXNQ==
 
 collect-v8-coverage@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4425,9 +4425,9 @@ path-key@^3.0.0, path-key@^3.1.0:
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-parse@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
-  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-platform@~0.11.15:
   version "0.11.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4544,10 +4544,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier-eslint@12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-12.0.0.tgz#b4dab5111aad1c0dca062eb7f92a69d5fb1ac1d3"
-  integrity sha512-N8SGGQwAosISXTNl1E57sBbtnqUGlyRWjcfIUxyD3HF4ynehA9GZ8IfJgiep/OfYvCof/JEpy9ZqSl250Wia7A==
+prettier-eslint@13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-13.0.0.tgz#769f5c04057278d071847d893ebc7b9817594184"
+  integrity sha512-P5K31qWgUOQCtJL/3tpvEe28KfP49qbr6MTVEXC7I2k7ci55bP3YDr+glhyCdhIzxGCVp2f8eobfQ5so52RIIA==
   dependencies:
     "@typescript-eslint/parser" "^3.0.0"
     common-tags "^1.4.0"
@@ -4575,17 +4575,7 @@ pretty-format@^23.0.1:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-pretty-format@^27.0.2:
-  version "27.0.2"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.0.2.tgz#9283ff8c4f581b186b2d4da461617143dca478a4"
-  integrity sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==
-  dependencies:
-    "@jest/types" "^27.0.2"
-    ansi-regex "^5.0.0"
-    ansi-styles "^5.0.0"
-    react-is "^17.0.1"
-
-pretty-format@^27.0.6:
+pretty-format@^27.0.2, pretty-format@^27.0.6:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.0.6.tgz#ab770c47b2c6f893a21aefc57b75da63ef49a11f"
   integrity sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1657,10 +1657,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codemirror@5.62.1:
-  version "5.62.1"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.62.1.tgz#917c7406c7b7f05b974c7fe4c4f2088ae64cc874"
-  integrity sha512-39ce8tHh/M9J+Epa90R5zMGg06pxVXc1+Y0SRR6eKaUjjzuj5iYkk7rHc2uU+FzvfsWYGEYKPFf0pBVBLmYXNQ==
+codemirror@5.62.2:
+  version "5.62.2"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.62.2.tgz#bce6d19c9829e6e788f83886d48ecf5c1e106e65"
+  integrity sha512-tVFMUa4J3Q8JUd1KL9yQzQB0/BJt7ZYZujZmTPgo/54Lpuq3ez4C8x/ATUY/wv7b7X3AUq8o3Xd+2C5ZrCGWHw==
 
 collect-v8-coverage@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1620,10 +1620,10 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.1.tgz#2fd46d9906a126965aa541345c499aaa18e8cd73"
   integrity sha512-jVamGdJPDeuQilKhvVn1h3knuMOZzr8QDnpk+M9aMlCaMkTDd6fBWPhiDqFvFZ07pL0liqabAiuy8SY4jGHeaw==
 
-clean-css@5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.1.3.tgz#42348778c3acb0083946ba340896802be5517ee2"
-  integrity sha512-qGXzUCDpLwAlPx0kYeU4QXjzQIcIYZbJjD4FNm7NnSjoP0hYMVZhHOpUYJ6AwfkMX2cceLRq54MeCgHy/va1cA==
+clean-css@5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.1.4.tgz#d191c98347f9fc36b301f99bb827898151175782"
+  integrity sha512-e6JAuR0T2ahg7fOSv98Nxqh7mHWOac5TaCSgrr61h/6mkPLwlxX38hzob4h6IKj/UHlrrLXvAEjWqXlvi8r8lQ==
   dependencies:
     source-map "~0.6.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1620,10 +1620,10 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.1.tgz#2fd46d9906a126965aa541345c499aaa18e8cd73"
   integrity sha512-jVamGdJPDeuQilKhvVn1h3knuMOZzr8QDnpk+M9aMlCaMkTDd6fBWPhiDqFvFZ07pL0liqabAiuy8SY4jGHeaw==
 
-clean-css@5.1.4:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.1.4.tgz#d191c98347f9fc36b301f99bb827898151175782"
-  integrity sha512-e6JAuR0T2ahg7fOSv98Nxqh7mHWOac5TaCSgrr61h/6mkPLwlxX38hzob4h6IKj/UHlrrLXvAEjWqXlvi8r8lQ==
+clean-css@5.1.5:
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.1.5.tgz#3b0af240dcfc9a3779a08c2332df3ebd4474f232"
+  integrity sha512-9dr/cU/LjMpU57PXlSvDkVRh0rPxJBXiBtD0+SgYt8ahTCsXtfKjCkNYgIoTC6mBg8CFr5EKhW3DKCaGMUbUfQ==
   dependencies:
     source-map "~0.6.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2083,16 +2083,6 @@ duplexer@^0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
   integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
 
-ecstatic@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/ecstatic/-/ecstatic-3.3.2.tgz#6d1dd49814d00594682c652adb66076a69d46c48"
-  integrity sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==
-  dependencies:
-    he "^1.1.1"
-    mime "^1.6.0"
-    minimist "^1.1.0"
-    url-join "^2.0.5"
-
 electron-to-chromium@^1.3.723:
   version "1.3.746"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.746.tgz#4ff1251986d751ba6e0acee516e04bc205511463"
@@ -2816,7 +2806,7 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-he@^1.1.1:
+he@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -2877,21 +2867,23 @@ http-proxy@^1.18.0:
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
 
-http-server@0.12.3:
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/http-server/-/http-server-0.12.3.tgz#ba0471d0ecc425886616cb35c4faf279140a0d37"
-  integrity sha512-be0dKG6pni92bRjq0kvExtj/NrrAd28/8fCXkaI/4piTwQMSDSLMhWyW0NI1V+DBI3aa1HMlQu46/HjVLfmugA==
+http-server@13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/http-server/-/http-server-13.0.0.tgz#27ab5f3bad0e27a29965a4029c26170162f7b98f"
+  integrity sha512-tqOx2M1CiZ3aVaE7Ue/0lup9kOG+Zqg6wdT1HygvxFnvPpU9doBMPcQ1ffT0/QS3J9ua35gipg0o3Dr8N0K0Tg==
   dependencies:
     basic-auth "^1.0.3"
     colors "^1.4.0"
     corser "^2.0.1"
-    ecstatic "^3.3.2"
+    he "^1.1.0"
     http-proxy "^1.18.0"
+    mime "^1.6.0"
     minimist "^1.2.5"
     opener "^1.5.1"
     portfinder "^1.0.25"
     secure-compare "3.0.1"
     union "~0.5.0"
+    url-join "^2.0.5"
 
 https-browserify@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Prevents error created by clicking in between example choices (#587)
- chore(deps): bump codemirror from 5.62.0 to 5.62.1 (#590)
- chore(deps): bump codemirror from 5.62.1 to 5.62.2 (#591)
- chore(deps-dev): bump prettier-eslint from 12.0.0 to 13.0.0 (#592)
- chore(deps): bump clean-css from 5.1.3 to 5.1.4 (#594)
- chore(deps): bump clean-css from 5.1.4 to 5.1.5 (#595)
- chore(deps-dev): bump http-server from 0.12.3 to 13.0.0 (#596)
- chore(deps): bump path-parse from 1.0.6 to 1.0.7 (#597)
- fix: do not auto focus js editor
